### PR TITLE
Implement backwards compatibility mode for Python 2

### DIFF
--- a/Lib/ldap/functions.py
+++ b/Lib/ldap/functions.py
@@ -74,7 +74,7 @@ def _ldap_function_call(lock,func,*args,**kwargs):
   return result
 
 
-def initialize(uri,trace_level=0,trace_file=sys.stdout,trace_stack_limit=None):
+def initialize(uri,trace_level=0,trace_file=sys.stdout,trace_stack_limit=None, bytes_mode=None):
   """
   Return LDAPObject instance by opening LDAP connection to
   LDAP host specified by LDAP URL
@@ -88,11 +88,13 @@ def initialize(uri,trace_level=0,trace_file=sys.stdout,trace_stack_limit=None):
   trace_file
         File object where to write the trace output to.
         Default is to use stdout.
+  bytes_mode
+        Whether to enable "bytes_mode" for backwards compatibility under Py2.
   """
-  return LDAPObject(uri,trace_level,trace_file,trace_stack_limit)
+  return LDAPObject(uri,trace_level,trace_file,trace_stack_limit,bytes_mode)
 
 
-def open(host,port=389,trace_level=0,trace_file=sys.stdout,trace_stack_limit=None):
+def open(host,port=389,trace_level=0,trace_file=sys.stdout,trace_stack_limit=None,bytes_mode=None):
   """
   Return LDAPObject instance by opening LDAP connection to
   specified LDAP host
@@ -107,10 +109,12 @@ def open(host,port=389,trace_level=0,trace_file=sys.stdout,trace_stack_limit=Non
   trace_file
         File object where to write the trace output to.
         Default is to use stdout.
+  bytes_mode
+        Whether to enable "bytes_mode" for backwards compatibility under Py2.
   """
   import warnings
   warnings.warn('ldap.open() is deprecated! Use ldap.initialize() instead.', DeprecationWarning,2)
-  return initialize('ldap://%s:%d' % (host,port),trace_level,trace_file,trace_stack_limit)
+  return initialize('ldap://%s:%d' % (host,port),trace_level,trace_file,trace_stack_limit,bytes_mode)
 
 init = open
 

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -115,7 +115,7 @@ class SimpleLDAPObject:
       return value
     elif self.bytes_mode:
       if not isinstance(value, bytes):
-        raise TypeError("All provided fields *must* be bytes in bytes mode; got %r" % (value,))
+        raise TypeError("All provided fields *must* be bytes when bytes mode is on; got %r" % (value,))
       return value.decode('utf-8')
     else:
       if not isinstance(value, text_type):

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -445,7 +445,7 @@ class SubSchema:
     return r_must,r_may # attribute_types()
 
 
-def urlfetch(uri,trace_level=0):
+def urlfetch(uri,trace_level=0,bytes_mode=None):
   """
   Fetches a parsed schema entry by uri.
 
@@ -457,7 +457,7 @@ def urlfetch(uri,trace_level=0):
   if uri.startswith('ldap:') or uri.startswith('ldaps:') or uri.startswith('ldapi:'):
     import ldapurl
     ldap_url = ldapurl.LDAPUrl(uri)
-    l=ldap.initialize(ldap_url.initializeUrl(),trace_level)
+    l=ldap.initialize(ldap_url.initializeUrl(),trace_level,bytes_mode=bytes_mode)
     l.protocol_version = ldap.VERSION3
     l.simple_bind_s(ldap_url.who or '', ldap_url.cred or '')
     subschemasubentry_dn = l.search_subschemasubentry_s(ldap_url.dn)

--- a/README
+++ b/README
@@ -19,6 +19,48 @@ According to this, releases of ``pyldap`` will stick to the numbering of the ups
 
 However, some compatibility toggles will be added to bring cleaner APIs for PY3 code.
 
+Please note the ``pyldap`` installs under the same ``ldap`` module as ``python-ldap``; it **CANNOT** be installed alongside.
+
+
+--------------------------
+Upgrading from python-ldap
+--------------------------
+
+``pyldap`` brings some improvements on top of ``python-ldap``.
+
+
+Bytes/text management
+=====================
+
+The LDAP protocol states that some fields (distinguised names, relative distinguished names,
+attribute names, queries) be encoded in UTF-8; some other (mostly attribute *values*) **MAY**
+contain any type of data, and thus be treated as bytes.
+
+However, ``python-ldap`` used bytes for all fields, including those guaranteed to be text.
+In order to support Python 3, ``pyldap`` needs to make this distinction explicit; this is done
+through the ``bytes_mode`` flag to ``ldap.initialize()``.
+
+When porting from ``python-ldap``, users are advised to update their code to set ``bytes_mode=False``
+on calls to these methods.
+Under Python 2, ``pyldap`` checks aggressively the type of provided arguments, and will raise a ``TypeError``
+for any invalid parameter.
+
+The typical usage is as follow; note that only the result's *values* are of the bytes type:
+
+.. code-block:: pycon
+
+    >>> import ldap
+    >>> con = ldap.initialize('ldap://localhost:389', bytes_mode=False)
+    >>> con.simple_bind_s('login', 'secret_password')
+    >>> results = con.search_s('ou=people,dc=example,dc=org', ldap.SCOPE_SUBTREE, "(cn=Raphaël)")
+    >>> results
+    [
+        ("cn=Raphaël,ou=people,dc=example,dc=org", {
+            'cn': [b'Rapha\xc3\xabl'],
+            'sn': [b'Barrois'],
+        }),
+    ]
+
 
 ---------------------------------------
 python-ldap: LDAP client API for Python


### PR DESCRIPTION
With this commit, all ldap connections accept a new parameter,
`bytes_mode`.

When set to `True`, this flag emulates the old Python 2 behavior,
where all fields are bytes - including those declared as UTF-8 by the RFC (DN,
RDN, attribute names).

If this flag is set to `False`, the code works with text (unicode) for all
text fields (everything except attribute values).

If no value is set under Python 2, the code will raise a BytesWarning
and proceed with the flag set to `True`, for backwards compatibility.
Under Python 3, the value can only be set to `False`.

For safety and ease of upgrade, the code checks that all provided
arguments are of the expected type (unicode with `bytes_mode=False`,
bytes with `bytes_mode=True`).
