### PR TITLE
Speed ups for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 addons:
   apt:
     packages:
@@ -16,6 +20,7 @@ matrix:
     - python: "3.4"
       env: TOXENV=py34
 install:
+  - pip install "pip>=7.1.0"
   - pip install tox
 
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
-sudo: true
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - ldap-utils
+      - slapd
+
 matrix:
   include:
     - python: "2.7"
@@ -8,10 +15,7 @@ matrix:
       env: TOXENV=py33
     - python: "3.4"
       env: TOXENV=py34
-before_install:
-  - sudo apt-get update -qq
 install:
-  - sudo apt-get install -qq ldap-utils slapd
   - pip install tox
 
 script: tox


### PR DESCRIPTION
- Use container based build machines
- Install Python requirements from wheels, and cache them
