### PR TITLE
Change include path of sasl.h for Mac OS X

### DIFF
--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -15,7 +15,11 @@
 #include "options.h"
 
 #ifdef HAVE_SASL
+#ifdef __APPLE__
+#include <sasl/sasl.h>
+#else
 #include <sasl.h>
+#endif
 #endif
 
 static void free_attrs(char***);


### PR DESCRIPTION
It works on El Capitan.
