### PR TITLE
Validate LDAP connection in whoami_s()

### DIFF
--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -1182,6 +1182,7 @@ l_ldap_whoami_s( LDAPObject* self, PyObject* args )
     int ldaperror;
 
     if (!PyArg_ParseTuple( args, "|OO", &serverctrls, &clientctrls)) return NULL;
+    if (not_valid(self)) return NULL;
 
     if (!PyNone_Check(serverctrls)) {
         if (!LDAPControls_from_object(serverctrls, &server_ldcs))

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -511,6 +511,13 @@ class TestLdapCExtension(unittest.TestCase):
         r = l.whoami_s()
         self.assertEqual("", r)
 
+    def test_whoami_after_unbind(self):
+        # https://github.com/pyldap/pyldap/issues/29
+        l = self._init()
+        l.unbind_ext()
+        with self.assertRaises(_ldap.LDAPError):
+            l.whoami_s()
+
     def test_passwd(self):
         l = self._init()
 


### PR DESCRIPTION
l_ldap_whoami_s() was missing a call to not_valid(). An invalid or
closed connection lead to a segfault.

This bug was reported by Florent Xicluna.

Closes: #29

Signed-off-by: Christian Heimes cheimes@redhat.com
