### PR TITLE
Travis CI: Use tox-travis to make .travis.yml more readable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+python:
+- '2.7'
+- '3.3'
+- '3.4'
+- '3.5'
 sudo: false
 
 cache:
@@ -11,18 +16,8 @@ addons:
       - ldap-utils
       - slapd
 
-matrix:
-  include:
-    - python: "2.7"
-      env: TOXENV=py27
-    - python: "3.3"
-      env: TOXENV=py33
-    - python: "3.4"
-      env: TOXENV=py34
-    - python: "3.5"
-      env: TOXENV=py35
 install:
   - pip install "pip>=7.1.0"
-  - pip install tox
+  - pip install tox-travis tox
 
 script: tox


### PR DESCRIPTION
Works nice, doesn't require matrix specification.
