### PR TITLE
Add pyldap_version constant to allow ID of ldap implementation.

### DIFF
--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -22,6 +22,8 @@ if __debug__:
 import _ldap
 from _ldap import *
 
+PYLDAP_VERSION = __version__
+
 OPT_NAMES_DICT = {}
 for k,v in vars(_ldap).items():
   if k.startswith('OPT_'):


### PR DESCRIPTION
Bug Description:  Pyldap changes _just_ enough to break compatability between
python ldap, and pyldap.

Fix Description:  To allow users to detect what behaviour they need to use,
they can look for the "well known" flag ldap.PYLDAP_VERSION. If it doesn't
exist, then we it can be determined we are on python-ldap.

The following pattern can be used:

if hasattr(ldap, 'PYLDAP_VERSION'):
    # Do pyldap behaviour
else:
    # Do python-ldap behaviour
