### PR TITLE
Bug Description:  ldap's add_s breaks when using a two tuple add list.

### DIFF
--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -161,10 +161,21 @@ class SimpleLDAPObject:
     """
     if not PY2:
       return modlist
-    return tuple(
-      (op, self._unbytesify_value(attr), val)
-      for op, attr, val in modlist
-    )
+    # This breaks on the "add" family of operations, whos modlist is (attr, val)
+    # rather than (op, attr, val). we need to make this distinction.
+    if len(modlist) == 0: #be paranoid
+        return ()
+    if len(modlist[0]) == 3:
+        return tuple(
+          (op, self._unbytesify_value(attr), val)
+          for op, attr, val in modlist
+        )
+    # This is probably an add modlist
+    if len(modlist[0]) == 2:
+        return tuple(
+          (self._unbytesify_value(attr), val)
+          for attr, val in modlist
+        )
 
   def _bytesify_value(self, value):
     """Adapt a returned value according to bytes_mode.


### PR DESCRIPTION
/usr/lib64/python2.7/site-packages/pyldap-2.4.25-py2.7-linux-x86_64.egg/ldap/ldapobject.py:166: in _unbytesify_modlist
    for op, attr, val in modlist

---

.0 = <listiterator object at 0x186ded0>

>   (op, self._unbytesify_value(attr), val)
>     for op, attr, val in modlist
>         )
> E       ValueError: need more than 2 values to unpack

Fix Description:  Detect the type of modlist, if it is 2 or 3 tuple and
accordingly change our behaviour to suit.

Example:

conn.add_s("uid=user1,ou=people,dc=example,dc=com",
            [('cn', ['user1']), ('description', ['user description']), ('objectclass', ['top', 'posixAccount', 'person']), ('uidNumber', ['1']), ('gidNumber', ['1']), ('sn', ['test']), ('homeDirectory', ['/home/user1']), ('uid', ['user1'])]
            )
