### PR TITLE
Look into LIBRARY_PATH and INCLUDE_PATH environment variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,18 @@ for i in range(len(LDAP_CLASS.extra_files)):
   origfileslist = string_split(origfiles, ',')
   LDAP_CLASS.extra_files[i]=(destdir, origfileslist)
 
+# Expand library_dirs and include_dirs from environment variables, makes
+# pyldap work with the apt buildpack on Heroku, for example.
+def expandvars(name):
+    return [os.path.expandvars(x)
+            for x in os.environ.get(name, '').split(':') if x]
+LDAP_CLASS.library_dirs += expandvars('LIBRARY_PATH')
+LDAP_CLASS.include_dirs += expandvars('INCLUDE_PATH')
+
+# Add "sasl" subdirectory to include_dirs
+LDAP_CLASS.include_dirs += [
+    os.path.join(x, 'sasl') for x in expandvars('INCLUDE_PATH')]
+
 #-- Let distutils/setuptools do the rest
 name = 'pyldap'
 


### PR DESCRIPTION
This makes the library build with non-standard paths, such as occuring
when deploying to Heroku.

Signed-off-by: Manuel Holtgrewe manuel.holtgrewe@bihealth.de
