### PR TITLE
Added trove classifiers to setup.setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,8 @@ setup(
     'Operating System :: POSIX',
     'Programming Language :: C',
     'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 3',
     'Topic :: Database',
     'Topic :: Internet',
     'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Indicates support for Python 2 and Python 3.

Similar changes should be made to https://pypi.python.org/pypi/pyldap to avoid being listed as `red` on http://python3wos.appspot.com/

Full list of trove classifiers https://pypi.python.org/pypi?%3Aaction=list_classifiers
