### PR TITLE
Force new-style classes

### DIFF
--- a/Demo/paged_search_ext_s.py
+++ b/Demo/paged_search_ext_s.py
@@ -11,7 +11,7 @@ import ldap,pprint
 from ldap.controls import SimplePagedResultsControl
 
 
-class PagedResultsSearchObject:
+class PagedResultsSearchObject(object):
   page_size = 50
 
   def paged_search_ext_s(self,base,scope,filterstr='(objectClass=*)',attrlist=None,attrsonly=0,serverctrls=None,clientctrls=None,timeout=-1,sizelimit=0):

--- a/Lib/dsml.py
+++ b/Lib/dsml.py
@@ -31,7 +31,7 @@ def replace_char(s):
   return s
 
 
-class DSMLWriter:
+class DSMLWriter(object):
   """
   Class for writing LDAP entry records to a DSMLv1 file.
 

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -29,7 +29,7 @@ for k,v in vars(_ldap).items():
   if k.startswith('OPT_'):
     OPT_NAMES_DICT[v]=k
 
-class DummyLock:
+class DummyLock(object):
   """Define dummy class with methods compatible to threading.Lock"""
   def __init__(self):
     pass
@@ -48,7 +48,7 @@ else:
   LDAPLockBaseClass = threading.Lock
 
 
-class LDAPLock:
+class LDAPLock(object):
   """
   Mainly a wrapper class to log all locking events.
   Note that this cumbersome approach with _lock attribute was taken

--- a/Lib/ldap/async.py
+++ b/Lib/ldap/async.py
@@ -40,7 +40,7 @@ class WrongResultType(Exception):
     )
 
 
-class AsyncSearchHandler:
+class AsyncSearchHandler(object):
   """
   Class for stream-processsing LDAP search results
 

--- a/Lib/ldap/controls/__init__.py
+++ b/Lib/ldap/controls/__init__.py
@@ -42,7 +42,7 @@ except ImportError:
   PyAsn1Error = None
 
 
-class RequestControl:
+class RequestControl(object):
   """
   Base class for all request controls
 
@@ -68,7 +68,7 @@ class RequestControl:
     return self.encodedControlValue
 
 
-class ResponseControl:
+class ResponseControl(object):
   """
   Base class for all response controls
 

--- a/Lib/ldap/controls/openldap.py
+++ b/Lib/ldap/controls/openldap.py
@@ -45,7 +45,7 @@ class SearchNoOpControl(ValueLessRequestControl,ResponseControl):
 ldap.controls.KNOWN_RESPONSE_CONTROLS[SearchNoOpControl.controlType] = SearchNoOpControl
 
 
-class SearchNoOpMixIn:
+class SearchNoOpMixIn(object):
   """
   Mix-in class to be used with class LDAPObject and friends.
 

--- a/Lib/ldap/extop/__init__.py
+++ b/Lib/ldap/extop/__init__.py
@@ -14,7 +14,7 @@ response.
 from ldap import __version__
 
 
-class ExtendedRequest:
+class ExtendedRequest(object):
   """
   Generic base class for a LDAPv3 extended operation request
 
@@ -40,7 +40,7 @@ class ExtendedRequest:
     return self.requestValue
 
 
-class ExtendedResponse:
+class ExtendedResponse(object):
   """
   Generic base class for a LDAPv3 extended operation response
 

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -56,7 +56,7 @@ class NO_UNIQUE_ENTRY(ldap.NO_SUCH_OBJECT):
   """
 
 
-class SimpleLDAPObject:
+class SimpleLDAPObject(object):
   """
   Drop-in wrapper class around _ldap.LDAPObject
   """

--- a/Lib/ldap/logger.py
+++ b/Lib/ldap/logger.py
@@ -5,7 +5,7 @@ Helper class for using logging as trace file object
 
 import logging
 
-class logging_file_class:
+class logging_file_class(object):
 
   def __init__(self,logging_level):
     self._logging_level = logging_level

--- a/Lib/ldap/resiter.py
+++ b/Lib/ldap/resiter.py
@@ -10,7 +10,7 @@ Requires Python 2.3+
 """
 
 
-class ResultProcessor:
+class ResultProcessor(object):
   """
   Mix-in class used with ldap.ldapopbject.LDAPObject or derived classes.
   """

--- a/Lib/ldap/sasl.py
+++ b/Lib/ldap/sasl.py
@@ -33,7 +33,7 @@ CB_ECHOPROMPT  = 0x4005
 CB_NOECHOPROMPT= 0x4006
 CB_GETREALM    = 0x4008
 
-class sasl:
+class sasl(object):
     """This class handles SASL interactions for authentication.
     If an instance of this class is passed to ldap's sasl_bind_s()
     method, the library will call its callback() method. For

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -27,7 +27,7 @@ NOT_HUMAN_READABLE_LDAP_SYNTAXES = {
 }
 
 
-class SchemaElement:
+class SchemaElement(object):
   """
   Base class for all schema element classes. Not used directly!
 

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -44,7 +44,7 @@ class NameNotUnique(SubschemaError):
     return 'NAME not unique for %s' % (self.desc)
 
 
-class SubSchema:
+class SubSchema(object):
   """
   Arguments:
 

--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -252,7 +252,7 @@ class syncInfoValue(univ.Choice):
         )
     )
 
-class SyncInfoMessage:
+class SyncInfoMessage(object):
     responseName = '1.3.6.1.4.1.4203.1.9.1.4'
 
     def __init__(self, encodedMessage):
@@ -292,7 +292,7 @@ class SyncInfoMessage:
                 return
 
 
-class SyncreplConsumer:
+class SyncreplConsumer(object):
     """
     SyncreplConsumer - LDAP syncrepl consumer object.
     """

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -63,7 +63,7 @@ def ldapUrlEscape(s):
   return quote(s).replace(',','%2C').replace('/','%2F')
 
 
-class LDAPUrlExtension:
+class LDAPUrlExtension(object):
   """
   Class for parsing and unparsing LDAP URL extensions
   as described in RFC 4516.
@@ -186,7 +186,7 @@ class LDAPUrlExtensions(UserDict):
     return ','.join([ v.unparse() for v in self.values() ])
 
 
-class LDAPUrl:
+class LDAPUrl(object):
   """
   Class for parsing and unparsing LDAP URLs
   as described in RFC 4516.

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -84,7 +84,7 @@ def list_dict(l):
   return dict([(i,None) for i in l])
 
 
-class LDIFWriter:
+class LDIFWriter(object):
   """
   Write LDIF entry or change records to file object
   Copy LDIF input to a file output object containing all data retrieved
@@ -248,7 +248,7 @@ def CreateLDIF(dn,record,base64_attrs=None,cols=76):
   return s
 
 
-class LDIFParser:
+class LDIFParser(object):
   """
   Base class for a LDIF parser. Applications should sub-class this
   class and override method handle() to implement something meaningful.

--- a/Tests/slapd.py
+++ b/Tests/slapd.py
@@ -41,7 +41,7 @@ def find_available_tcp_port(host=LOCALHOST):
     _log.info("Found available port %d", port)
     return port
 
-class Slapd:
+class Slapd(object):
     """
     Controller class for a slapd instance, OpenLDAP's server.
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ while s:
 f.close()
 
 #-- A class describing the features and requirements of OpenLDAP 2.0
-class OpenLDAP2:
+class OpenLDAP2(object):
   library_dirs = []
   include_dirs = []
   extra_compile_args = []


### PR DESCRIPTION
new-style classes were introduced in 2.2 (~15 years ago) but became default
only in Python 3. This patch forces classes to be new-style in both Python 2
and Python 3 by making the classes inherit from `object`. This has no effect
on Python 3.

This change is motivated by a project that needs to run on Python 2. Without
new-style classes, Python 3 developers would be forced to use antiquated
idioms (e.g. old-style classes can't use `super()`).
