### PR TITLE
Incorrect encode on unparse for python 3

### DIFF
--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -207,8 +207,6 @@ class LDIFWriter:
           or a list with a modify list like for LDAPObject.modify().
     """
     # Start with line containing the distinguished name
-    if not isinstance(dn, bytes):
-        dn = dn.encode('utf-8')
     self._unparseAttrTypeandValue('dn', dn)
     # Dispatch to record type specific writers
     if isinstance(record, dict):


### PR DESCRIPTION
Bug Description:
File "/usr/lib64/python3.5/site-packages/ldif.py", line 213, in unparse
self._unparseAttrTypeandValue('dn', dn)
File "/usr/lib64/python3.5/site-packages/ldif.py", line 151, in _unparseAttrTypeandValue
if self._needs_base64_encoding(attr_type,attr_value):
File "/usr/lib64/python3.5/site-packages/ldif.py", line 140, in _needs_base64_encoding
not safe_string_re.search(attr_value) is None
TypeError: cannot use a string pattern on a bytes-like object

Fix Description:  Remove the incorrect encode

Author: wibrown
