### PR TITLE
Fix addModlist on python3.

### DIFF
--- a/Lib/ldap/modlist.py
+++ b/Lib/ldap/modlist.py
@@ -42,7 +42,7 @@ def addModlist(entry,ignore_attr_types=None):
       # This attribute type is ignored
       continue
     # Eliminate empty attr value strings in list
-    attrvaluelist = filter(lambda x:x!=None,entry[attrtype])
+    attrvaluelist = [item for item in entry[attrtype] if item is not None]
     if attrvaluelist:
       modlist.append((attrtype,entry[attrtype]))
   return modlist # addModlist()
@@ -82,10 +82,10 @@ def modifyModlist(
       # This attribute type is ignored
       continue
     # Filter away null-strings
-    new_value = list(filter(lambda x:x!=None,new_entry[attrtype]))
+    new_value = [item for item in new_entry[attrtype] if item is not None]
     if attrtype_lower in attrtype_lower_map:
       old_value = old_entry.get(attrtype_lower_map[attrtype_lower],[])
-      old_value = list(filter(lambda x:x!=None,old_value))
+      old_value = [item for item in old_value if item is not None]
       del attrtype_lower_map[attrtype_lower]
     else:
       old_value = []


### PR DESCRIPTION
With python3 filter returns a filter object, which will always be true, so
convert to a list to get the actual entries.

Note that this already has a test (test_modlist.py) that picked this up,
but its not a standard python unittest so isn't run by default.