### PR TITLE
Add bytes_mode flag to NonblockingLDAPObject and ReconnectLDAPObject

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,14 @@
 ----------------------------------------------------------------
+Released 2.4.28 2017-01-16
+
+Changes since 2.4.27:
+
+* Add byes_mode flag to NonblockingLDAPObject, ReconnectLDAPObject
+* Fix addModlist on python3
+* Restore support for UTF-8 values in ldif
+* [py3] Fix LDIF parsing
+
+----------------------------------------------------------------
 Released 2.4.27 2016-08-01 (upstream)
 
 Changes since 2.4.26:

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -8,7 +8,7 @@ $Id: __init__.py,v 1.105 2016/07/30 16:18:47 stroeder Exp $
 
 # This is also the overall release version number
 
-__version__ = '2.4.27'
+__version__ = '2.4.28'
 
 import sys
 

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -939,9 +939,13 @@ class SimpleLDAPObject:
 
 class NonblockingLDAPObject(SimpleLDAPObject):
 
-  def __init__(self,uri,trace_level=0,trace_file=None,result_timeout=-1):
+  def __init__(
+    self,uri,
+    trace_level=0,trace_file=None,bytes_mode=None,
+    result_timeout=-1
+  ):
     self._result_timeout = result_timeout
-    SimpleLDAPObject.__init__(self,uri,trace_level,trace_file)
+    SimpleLDAPObject.__init__(self,uri,trace_level,trace_file,bytes_mode)
 
   def result(self,msgid=ldap.RES_ANY,all=1,timeout=-1):
     """
@@ -993,7 +997,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
 
   def __init__(
     self,uri,
-    trace_level=0,trace_file=None,trace_stack_limit=5,
+    trace_level=0,trace_file=None,trace_stack_limit=5,bytes_mode=None,
     retry_max=1,retry_delay=60.0
   ):
     """
@@ -1008,7 +1012,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
     self._uri = uri
     self._options = []
     self._last_bind = None
-    SimpleLDAPObject.__init__(self,uri,trace_level,trace_file,trace_stack_limit)
+    SimpleLDAPObject.__init__(self,uri,trace_level,trace_file,trace_stack_limit,bytes_mode)
     self._reconnect_lock = ldap.LDAPLock(desc='reconnect lock within %s' % (repr(self)))
     self._retry_max = retry_max
     self._retry_delay = retry_delay

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ cfg.read('setup.cfg')
 if cfg.has_section('_ldap'):
   for name in dir(LDAP_CLASS):
     if cfg.has_option('_ldap', name):
-      print(name + ': ' + cfg.get('_ldap', name))
       setattr(LDAP_CLASS, name, string_split(cfg.get('_ldap', name)))
 
 for i in range(len(LDAP_CLASS.defines)):

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ for i in range(len(LDAP_CLASS.extra_files)):
   LDAP_CLASS.extra_files[i]=(destdir, origfileslist)
 
 #-- Let distutils/setuptools do the rest
-name = 'pyldap'
+name = 'pyldap-ugent'
 
 # Python 2.3.6+ and setuptools are needed to build eggs, so
 # let's handle setuptools' additional  keyword arguments to
@@ -103,8 +103,7 @@ setup(
   and controls, etc.). 
   """,
   author = 'pyldap project',
-  url = 'https://github.com/pyldap/pyldap/',
-  download_url = 'https://pypi.python.org/pypi/pyldap/',
+  url = 'https://github.com/UGentPortaal-pyldap-ugent',
   classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
In #7, a backwards compatibility mode for Python 2 was implemented by adding a new parameter `bytes_mode` to the SimpleLDAPObject constructor.

With this commit, the parameter `bytes_mode` is added to the constructors of NonblockingLDAPObject and ReconnectLDAPObject (which is then purely passed to the SimpleLDAPObject constructor). This enables the use of these objects under Python 2.