### PR TITLE
backport fix for errno-related regression introduced in 2.4.35

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Changes since 2.4.36:
 
 Lib/
 * fixed errno-related regression introduced in 2.4.35
+* fixed errno-related ldap.TIMEOUT regression
 
 ----------------------------------------------------------------
 Released 2.4.35 2017-04-25 (upstream)

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,12 @@
 ----------------------------------------------------------------
+Released 2.4.35.1 2017-05-29 (pyldap)
+
+Changes since 2.4.36:
+
+Lib/
+* fixed errno-related regression introduced in 2.4.35
+
+----------------------------------------------------------------
 Released 2.4.35 2017-04-25 (upstream)
 
 Changes since 2.4.33:

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -269,8 +269,11 @@ class SimpleLDAPObject:
       finally:
         self._ldap_object_lock.release()
     except LDAPError as e:
-      if 'info' not in e.args[0] and 'errno' in e.args[0]:
+      try:
+        if 'info' not in e.args[0] and 'errno' in e.args[0]:
           e.args[0]['info'] = strerror(e.args[0]['errno'])
+      except IndexError:
+        pass
       if __debug__ and self._trace_level>=2:
         self._trace_file.write('=> LDAPError - %s: %s\n' % (e.__class__.__name__,str(e)))
       raise

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -269,8 +269,8 @@ class SimpleLDAPObject:
       finally:
         self._ldap_object_lock.release()
     except LDAPError as e:
-      if 'info' not in e.args[0]:
-        e.args[0]['info'] = strerror(e.args[0]['errno'])
+      if 'info' not in e.args[0] and 'errno' in e.args[0]:
+          e.args[0]['info'] = strerror(e.args[0]['errno'])
       if __debug__ and self._trace_level>=2:
         self._trace_file.write('=> LDAPError - %s: %s\n' % (e.__class__.__name__,str(e)))
       raise


### PR DESCRIPTION
This is a backport from python-ldap 2.4.37

The regression hit quite a few people (see #90). I think it's worth it to release pyldap 2.4.35.1 with this fix now, rather than rush changes from python-ldap 2.4.36 and 2.4.37.