### PR TITLE
Improve unicode handling in Python 2

### DIFF
--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -112,7 +112,7 @@ class SimpleLDAPObject:
   def _bytesify_input(self, value):
     """Adapt a value following bytes_mode in Python 2.
 
-    In Python 3, is a no-op.
+    In Python 3, returns the original value unmodified.
 
     With bytes_mode ON, takes bytes or None and returns bytes or None.
     With bytes_mode OFF, takes unicode or None and returns bytes or None.
@@ -185,16 +185,16 @@ class SimpleLDAPObject:
     With bytes_mode OFF, takes bytes or None and returns unicode or None.
     """
     if value is None:
-        return value
+      return value
 
     # Preserve logic of assertions only under Python 2
     if PY2:
       assert isinstance(value, bytes), "Expected bytes value, got text instead (%r)" % (value,)
 
     if self.bytes_mode:
-        return value
+      return value
     else:
-        return value.decode('utf-8')
+      return value.decode('utf-8')
 
   def _bytesify_value(self, value):
     """Adapt a returned value according to bytes_mode.

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -174,6 +174,24 @@ class SimpleLDAPObject:
         for attr, val in modlist
       )
 
+  def _unbytesify_result(self, value):
+    """Adapt a value following bytes_mode.
+
+    With bytes_mode ON, takes bytes or None and returns bytes or None.
+    With bytes_mode OFF, takes bytes or None and returns unicode or None.
+    """
+    if value is None:
+        return value
+
+    # Preserve logic of assertions only under Python 2
+    if PY2:
+      assert isinstance(value, bytes), "Expected bytes value, got text instead (%r)" % (value,)
+
+    if self.bytes_mode:
+        return value
+    else:
+        return value.decode('utf-8')
+
   def _bytesify_value(self, value):
     """Adapt a returned value according to bytes_mode.
 
@@ -871,7 +889,7 @@ class SimpleLDAPObject:
         else:
           # With legacy bytes mode, return bytes; otherwise, since this is a DN,
           # RFCs impose that the field value *can* be decoded to UTF-8.
-          return self._unbytesify_value(search_subschemasubentry_dn)
+          return self._unbytesify_result(search_subschemasubentry_dn)
     except IndexError:
       return None
 

--- a/Tests/t_bind.py
+++ b/Tests/t_bind.py
@@ -24,7 +24,6 @@ class TestBinds(unittest.TestCase):
         if server is None:
             server = slapd.Slapd()
             server.start()
-            base = server.get_dn_suffix()
 
         self.server = server
         self.unicode_val = "abc\U0001f498def"
@@ -68,8 +67,13 @@ class TestBinds(unittest.TestCase):
         l = self._get_ldapobject(False)
         with self.assertRaises(TypeError):
             l.simple_bind_s(self.dn_bytes, self.unicode_val)
+
+        # Works fine in Python 3 because 'cred' (the password) is read in
+        # using the "s#" format which, unlike "s", accepts either a str
+        # (unicode) *or* bytes.
+        #
         # with self.assertRaises(TypeError):
-        #     l.simple_bind_s(self.root_dn_unicode, self.root_pass_bytes)
+        #     l.simple_bind_s(self.dn_unicode, self.unicode_val_bytes)
 
         with self.assertRaises(ldap.INVALID_CREDENTIALS):
             l.simple_bind_s(self.dn_unicode, self.unicode_val)

--- a/Tests/t_bind.py
+++ b/Tests/t_bind.py
@@ -1,0 +1,79 @@
+from __future__ import unicode_literals
+
+import sys
+
+if sys.version_info[0] <= 2:
+    PY2 = True
+    text_type = unicode
+else:
+    PY2 = False
+    text_type = str
+
+import ldap, unittest
+from . import slapd
+
+from ldap.ldapobject import LDAPObject
+
+server = None
+
+
+class TestBinds(unittest.TestCase):
+
+    def setUp(self):
+        global server
+        if server is None:
+            server = slapd.Slapd()
+            server.start()
+            base = server.get_dn_suffix()
+
+        self.server = server
+        self.unicode_val = "abc\U0001f498def"
+        self.unicode_val_bytes = self.unicode_val.encode('utf-8')
+
+        self.dn_unicode = "CN=" + self.unicode_val
+        self.dn_bytes = self.dn_unicode.encode('utf-8')
+
+    def _get_ldapobject(self, bytes_mode=None):
+        l = LDAPObject(self.server.get_url(), bytes_mode=bytes_mode)
+        l.protocol_version = 3
+        l.set_option(ldap.OPT_REFERRALS,0)
+        return l
+
+    def test_simple_bind(self):
+        l = self._get_ldapobject(False)
+        with self.assertRaises(ldap.INVALID_CREDENTIALS):
+            l.simple_bind_s(self.dn_unicode, self.unicode_val)
+
+    def test_unicode_bind(self):
+        l = self._get_ldapobject(False)
+        l.simple_bind(self.dn_unicode, "ascii")
+
+        l = self._get_ldapobject(False)
+        l.simple_bind("CN=user", self.unicode_val)
+
+    @unittest.skipUnless(PY2, "no bytes_mode under Py3")
+    def test_unicode_bind_bytesmode(self):
+        l = self._get_ldapobject(True)
+        with self.assertRaises(TypeError):
+            l.simple_bind_s(self.dn_unicode, self.unicode_val_bytes)
+
+        with self.assertRaises(TypeError):
+            l.simple_bind_s(self.dn_bytes, self.unicode_val)
+
+        # Works when encoded to UTF-8
+        with self.assertRaises(ldap.INVALID_CREDENTIALS):
+            l.simple_bind_s(self.dn_bytes, self.unicode_val_bytes)
+
+    def test_unicode_bind_no_bytesmode(self):
+        l = self._get_ldapobject(False)
+        with self.assertRaises(TypeError):
+            l.simple_bind_s(self.dn_bytes, self.unicode_val)
+        # with self.assertRaises(TypeError):
+        #     l.simple_bind_s(self.root_dn_unicode, self.root_pass_bytes)
+
+        with self.assertRaises(ldap.INVALID_CREDENTIALS):
+            l.simple_bind_s(self.dn_unicode, self.unicode_val)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/t_search.py
+++ b/Tests/t_search.py
@@ -172,6 +172,17 @@ class TestSearch(unittest.TestCase):
             [('cn=Foo4,ou=Container,'+base, {'cn': [b'Foo4']})]
         )
 
+    def test_search_subschema(self):
+        dn = self.ldap.search_subschemasubentry_s()
+        self.assertIsInstance(dn, text_type)
+        self.assertEqual(dn, "cn=Subschema")
+
+    @unittest.skipUnless(PY2, "no bytes_mode under Py3")
+    def test_search_subschema_have_bytes(self):
+        l = self._get_bytes_ldapobject(explicit=False)
+        dn = l.search_subschemasubentry_s()
+        self.assertIsInstance(dn, bytes)
+        self.assertEqual(dn, b"cn=Subschema")
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/t_search.py
+++ b/Tests/t_search.py
@@ -128,6 +128,26 @@ class TestSearch(unittest.TestCase):
         l.search_s(base.encode('utf-8'), ldap.SCOPE_SUBTREE, b'(cn=Foo*)', ['*'])
         l.search_s(base, ldap.SCOPE_SUBTREE, b'(cn=Foo*)', [b'*'])
 
+    def test_search_accepts_unicode_dn(self):
+        base = self.server.get_dn_suffix()
+
+        with self.assertRaises(ldap.NO_SUCH_OBJECT):
+            result = self.ldap.search_s("CN=abc\U0001f498def", ldap.SCOPE_SUBTREE)
+
+    def test_filterstr_accepts_unicode(self):
+        base = self.server.get_dn_suffix()
+        result = self.ldap.search_s(base, ldap.SCOPE_SUBTREE, '(cn=abc\U0001f498def)', ['*'])
+        self.assertEqual(result, [])
+
+    def test_attrlist_accepts_unicode(self):
+        base = self.server.get_dn_suffix()
+        result = self.ldap.search_s(base, ldap.SCOPE_SUBTREE, '(cn=Foo*)', ['abc', 'abc\U0001f498def'])
+        result.sort()
+
+        for dn, attrs in result:
+            self.assertIsInstance(dn, text_type)
+            self.assertEqual(attrs, {})
+
     def test_search_subtree(self):
         base = self.server.get_dn_suffix()
         l = self.ldap

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py34
+envlist = py27,py34,py35,py36
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
Improve pyldap's handling of `unicode` strings containing non-ASCII characters (namely #54 and #39) that result from Python 2's "s" format unit trying to coerce `unicode` objects to a `char*` by way of the `ascii` encoding.

After looking at @koniiiik's diagnosis of the issues and suggestions in #54 (which was an immense time-saver), I decided that letting Python do most of the heavy lifting and memory management was best approach -- using the "es" format unit in the C bindings would have introduced the need for explicit memory management, and increased the ongoing maintenance burden (more changes across a number of the C bindings).

With the changes here:

- In Python 2, "text" values passed from Python to the C bindings are expected to be UTF-8 encoded `bytes` objects
- In Python 3, "text" values passed from Python to the C bindings are expected to be `unicode` objects, and we rely on Python to coerce that into a utf-8 representation (and handle memory management).

I also fixed two other issues while I was doing this, namely a memory leak in `attrs_from_List` (Python object leak) and the `subschemasubentry` DN decoding not actually working the way it's commented under Python 3 (`_unbytesify_value` was explicitly a no-op in Python 3, so the value was returned as a bytes object, rather than a string).