### PR TITLE
ldif.py: Fix comparison of bytes and unicode

### DIFF
--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -403,7 +403,7 @@ class LDIFParser:
     # Consume empty lines
     try:
       k,v = next_key_and_value()
-      while k==v==None:
+      while k is None and v is None:
         k,v = next_key_and_value()
     except EOFError:
       k,v = None,None


### PR DESCRIPTION
The original comparison made python3 sad with
"BytesWarning: Comparison between bytes and string"
warning.