### PR TITLE
UTF8-Encoding on string check

### DIFF
--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -186,7 +186,11 @@ class SimpleLDAPObject:
 
     if value is None:
       return value
-
+    
+    # Remove all characters that are non-utf compatible so that isinstance all valid characters as string instead of bytes
+    # This fixes issue #97: https://github.com/pyldap/pyldap/issues/97
+    value = value.decode("utf-8", "ignore")
+    
     assert isinstance(value, text_type), "Should return text, got bytes instead (%r)" % (value,)
     if not self.bytes_mode:
       return value


### PR DESCRIPTION
`isinstance(value, text_type)` checks whether the given string is unicode on Python 2.x or not. By converting them to UTF8 first and removing all non UTF8 characters, we make sure that this works correctly, and don't give us false errors like in issue #97 where a valid DN like `mail=user@example.com,ou=administratrators,ou=sub-users,ou=users,DC=myldap,DC=example,DC=com` is denied because of wrong encoding.