### PR TITLE
syncrepl: Cast string to bytes when creating UUID

### DIFF
--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -132,7 +132,9 @@ class SyncStateControl(ResponseControl):
     def decodeControlValue(self, encodedControlValue):
         d = decoder.decode(encodedControlValue, asn1Spec = syncStateValue())
         state = d[0].getComponentByName('state')
-        uuid = UUID(bytes=d[0].getComponentByName('entryUUID'))
+        # In Python 3, pyasn1.char overrides bytes() to do encoding for us.
+        # See also http://pyasn1.sourceforge.net/docs/type/univ/octetstring.html
+        uuid = UUID(bytes=bytes(d[0].getComponentByName('entryUUID')))
         self.cookie = d[0].getComponentByName('cookie')
         self.state = self.__class__.opnames[int(state)]
         self.entryUUID = str(uuid)
@@ -283,7 +285,10 @@ class SyncInfoMessage:
                     uuids = []
                     ids = comp.getComponentByName('syncUUIDs')
                     for i in range(len(ids)):
-                        uuid = UUID(bytes=str(ids.getComponentByPosition(i)))
+                        # In Python 3, pyasn1.char overrides bytes() to do
+                        # encoding for us.  See also:
+                        # http://pyasn1.sourceforge.net/docs/type/univ/octetstring.html
+                        uuid = UUID(bytes=bytes(ids.getComponentByPosition(i)))
                         uuids.append(str(uuid))
                     val['syncUUIDs'] = uuids
                     val['refreshDeletes'] = bool(comp.getComponentByName('refreshDeletes'))


### PR DESCRIPTION
Hello!

This PR fixes an issue that appears when using `ldap.syncrepl` on Python 3, related to UUID parsing.

The Syncrepl protocol involves UUIDs for identifying LDAP entries (since it is possible for DNs to change).  `ldap.syncrepl` uses the `UUID` class, and tells the class that the input to be parsed is bytes.  The problem is, on Python 3 the default string type has changed.

The fix I am pushing explicitly changes the input strings to `bytes`, so that they can be parsed.  This also works on Python 2, since there (if I understand correctly) doing `bytes` on a `str` is essentially a no-op.

I have submitted this upstream, but so far it has stalled on concerns[2] that `bytes` was only introduced in Python 2.6[1].

The reason I feel comfortable submitting here is that this is a change specifically for Python 3 support.  However, I'm not sure how old of a Python 2 is supported here.  If 2.6+ is the oldest supported Python here, then this should be fine.  If not, then I'll have to update the code to support older Python 2s.

One other concern might be that there is no test suite to evaluate this.  That is true, in that right now none of `ldap.syncrepl` has a test suite.  I have started working on one, and I have submitted a partial test suite upstream (see [3]), but so far it has not received a response.  I'm not sure how the test suites differ between `python-ldap` and `pyldap`, so I'm not sure what the work would be in converting (I'd still like to get my syncrepl test suite into `python-ldap`).

I think that's it!  Please let me know your thoughts.

[1] https://www.python.org/dev/peps/pep-0358/
[2] https://mail.python.org/pipermail/python-ldap/2017q2/003924.html
[3] https://mail.python.org/pipermail/python-ldap/2017q2/003923.html