### PR TITLE
[py3]: Avoid changing dictionary while looping through it

### DIFF
--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -427,7 +427,7 @@ class SubSchema:
     # Apply attr_type_filter to results
     if attr_type_filter:
       for l in [r_must,r_may]:
-        for a in l.keys():
+        for a in list(l.keys()):
           for afk,afv in attr_type_filter:
             try:
               schema_attr_type = self.sed[AttributeType][a]

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -420,7 +420,7 @@ class SubSchema:
 
     # Remove all mandantory attribute types from
     # optional attribute type list
-    for a in r_may.keys():
+    for a in list(r_may.keys()):
       if a in r_must:
         del r_may[a]
 

--- a/Tests/t_ldap_schema_subentry.py
+++ b/Tests/t_ldap_schema_subentry.py
@@ -7,6 +7,7 @@ import time
 
 import ldif
 import ldap.schema
+from ldap.schema.models import ObjectClass
 
 TEST_SUBSCHEMA_FILES = (
     'Tests/ldif/subschema-ipa.demo1.freeipa.org.ldif',
@@ -26,6 +27,15 @@ class TestSubschemaLDIF(unittest.TestCase):
             ldif_parser.parse()
             _, subschema_subentry = ldif_parser.all_records[0]
             sub_schema = ldap.schema.SubSchema(subschema_subentry)
+
+            # Smoke-check for listall() and attribute_types()
+            for objclass in sub_schema.listall(ObjectClass):
+                must, may = sub_schema.attribute_types([objclass])
+
+                for oid, attributetype in must.items():
+                    self.assertEqual(attributetype.oid, oid)
+                for oid, attributetype in may.items():
+                    self.assertEqual(attributetype.oid, oid)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is continuation of #104:

- Do the same fix a few lines down
- Smoke-test the fix to the original issue by calling attribute_types() for our test data