### PR TITLE
Use Travis CI built in support for cache pip downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ python:
 - '3.6-dev'
 sudo: false
 
-cache:
-  directories:
-    - $HOME/.cache/pip
+cache: pip
 
 addons:
   apt:


### PR DESCRIPTION
Avoid reimplementing it in some other way. Use builtin feature instead.

Travis CI's pip cache is documented at:

https://docs.travis-ci.com/user/caching/#pip-cache