### PR TITLE
Prefer assertEqual over assertEquals in tests

### DIFF
--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -181,7 +181,7 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertTrue('objectClass' in root_dse)
         self.assertTrue(b'OpenLDAProotDSE' in root_dse['objectClass'])
         self.assertTrue('namingContexts' in root_dse)
-        self.assertEquals(root_dse['namingContexts'], [self.server.suffix.encode('ascii')])
+        self.assertEqual(root_dse['namingContexts'], [self.server.suffix.encode('ascii')])
 
     def test_unbind(self):
         l = self._open_conn()

--- a/Tests/t_ldap_dn.py
+++ b/Tests/t_ldap_dn.py
@@ -19,13 +19,13 @@ class TestDN(unittest.TestCase):
         """
         test function is_dn()
         """
-        self.assertEquals(ldap.dn.is_dn('foobar,ou=ae-dir'), False)
-        self.assertEquals(ldap.dn.is_dn('-cn=foobar,ou=ae-dir'), False)
-        self.assertEquals(ldap.dn.is_dn(';cn=foobar,ou=ae-dir'), False)
-        self.assertEquals(ldap.dn.is_dn(',cn=foobar,ou=ae-dir'), False)
-        self.assertEquals(ldap.dn.is_dn('cn=foobar,ou=ae-dir,'), False)
-        self.assertEquals(ldap.dn.is_dn('uid=xkcd,cn=foobar,ou=ae-dir'), True)
-        self.assertEquals(
+        self.assertEqual(ldap.dn.is_dn('foobar,ou=ae-dir'), False)
+        self.assertEqual(ldap.dn.is_dn('-cn=foobar,ou=ae-dir'), False)
+        self.assertEqual(ldap.dn.is_dn(';cn=foobar,ou=ae-dir'), False)
+        self.assertEqual(ldap.dn.is_dn(',cn=foobar,ou=ae-dir'), False)
+        self.assertEqual(ldap.dn.is_dn('cn=foobar,ou=ae-dir,'), False)
+        self.assertEqual(ldap.dn.is_dn('uid=xkcd,cn=foobar,ou=ae-dir'), True)
+        self.assertEqual(
             ldap.dn.is_dn(
                 'cn=\xc3\xa4\xc3\xb6\xc3\xbc\xc3\x84\xc3\x96\xc3\x9c.o=\xc3\xa4\xc3\xb6\xc3\xbc\xc3\x84\xc3\x96\xc3\x9c\xc3\x9f'
             ),

--- a/Tests/t_ldap_filter.py
+++ b/Tests/t_ldap_filter.py
@@ -19,15 +19,15 @@ class TestDN(unittest.TestCase):
         """
         test function escape_filter_chars() with escape_mode=0
         """
-        self.assertEquals(
+        self.assertEqual(
             escape_filter_chars(r'foobar'),
             'foobar'
         )
-        self.assertEquals(
+        self.assertEqual(
             escape_filter_chars(r'foo\bar'),
             r'foo\5cbar'
         )
-        self.assertEquals(
+        self.assertEqual(
             escape_filter_chars(
                 r'foo\bar',
                 escape_mode=0
@@ -39,7 +39,7 @@ class TestDN(unittest.TestCase):
         """
         test function escape_filter_chars() with escape_mode=1
         """
-        self.assertEquals(
+        self.assertEqual(
             escape_filter_chars(
                 '\xc3\xa4\xc3\xb6\xc3\xbc\xc3\x84\xc3\x96\xc3\x9c\xc3\x9f',
                 escape_mode=1
@@ -51,7 +51,7 @@ class TestDN(unittest.TestCase):
         """
         test function escape_filter_chars() with escape_mode=2
         """
-        self.assertEquals(
+        self.assertEqual(
             escape_filter_chars(
                 'foobar',
                 escape_mode=2

--- a/Tests/t_ldap_functions.py
+++ b/Tests/t_ldap_functions.py
@@ -21,21 +21,21 @@ class TestFunction(unittest.TestCase):
         """
         test function ldap_strf_secs()
         """
-        self.assertEquals(ldap.strf_secs(0), '19700101000000Z')
-        self.assertEquals(ldap.strf_secs(1466947067), '20160626131747Z')
+        self.assertEqual(ldap.strf_secs(0), '19700101000000Z')
+        self.assertEqual(ldap.strf_secs(1466947067), '20160626131747Z')
 
     def test_ldap_strp_secs(self):
         """
         test function ldap_strp_secs()
         """
-        self.assertEquals(ldap.strp_secs('19700101000000Z'), 0)
-        self.assertEquals(ldap.strp_secs('20160626131747Z'), 1466947067)
+        self.assertEqual(ldap.strp_secs('19700101000000Z'), 0)
+        self.assertEqual(ldap.strp_secs('20160626131747Z'), 1466947067)
 
     def test_escape_str(self):
         """
         test function escape_string_tmpl()
         """
-        self.assertEquals(
+        self.assertEqual(
             ldap.escape_str(
                 escape_filter_chars,
                 '(&(objectClass=aeUser)(uid=%s))',
@@ -43,7 +43,7 @@ class TestFunction(unittest.TestCase):
             ),
             '(&(objectClass=aeUser)(uid=foo))'
         )
-        self.assertEquals(
+        self.assertEqual(
             ldap.escape_str(
                 escape_filter_chars,
                 '(&(objectClass=aeUser)(uid=%s))',
@@ -51,7 +51,7 @@ class TestFunction(unittest.TestCase):
             ),
             '(&(objectClass=aeUser)(uid=foo\\29bar))'
         )
-        self.assertEquals(
+        self.assertEqual(
             ldap.escape_str(
                 escape_dn_chars,
                 'uid=%s',
@@ -59,7 +59,7 @@ class TestFunction(unittest.TestCase):
             ),
             'uid=foo\\=bar'
         )
-        self.assertEquals(
+        self.assertEqual(
             ldap.escape_str(
                 escape_dn_chars,
                 'uid=%s,cn=%s,cn=%s,dc=example,dc=com',


### PR DESCRIPTION
Fixes deprecation warnings when running tests, like:

>  DeprecationWarning: Please use assertEqual instead.

For information on deprecated functions of unittest, see:

https://docs.python.org/3/library/unittest.html#deprecated-aliases