### PR TITLE
Always start LDAP server in SlapdTestCase setupClass method

### DIFF
--- a/Lib/slapdtest.py
+++ b/Lib/slapdtest.py
@@ -352,7 +352,7 @@ class SlapdTestCase(unittest.TestCase):
     def setUpClass(cls):
         if cls.server is None:
             cls.server = cls.server_class()
-            cls.server.start()
+        cls.server.start()
         cls.server = cls.server
 
     @classmethod


### PR DESCRIPTION
With the current code, if the t_cext.py tests run after the
t_ldapobject.py tests, they will fail. I believe the reason is
that when SlapdTestCase.tearDownClass() runs for the child class
TestLDAPObject, it stops the server. Then, when
SlapdTestCase.setUpClass() runs again for the child class
TestLdapCExtension, it doesn't actually start the server again,
because start() is only called in the `if cls.server is None:`
block, and it's *not* None at that point (because these are
*class* attributes not *instance* attributes, I believe).

One thing I can't explain is that we don't have the reverse
problem: if t_ldapobject tests run after t_cext tests, both
sets of tests pass. I can only think this is something to do
with the way t_ldapobject calls _open_ldap_conn in setUp(), but
I'm not 100% sure.

In any case, just moving the `cls.server.start()` call out of
the conditional like this seems to solve the problem: now the
tests pass no matter which order they run in. It's also worth
noting that python-ldap doesn't bother with this conditional at
all, it just does the same thing every time. Just dropping the
conditional, so pyldap's setUpClass looked the same as ldap's,
would likely also fix the bug.

Signed-off-by: Adam Williamson <awilliam@redhat.com>