### PR TITLE
Accommodate changed pyasn1 behaviour

### DIFF
--- a/Lib/ldap/controls/ppolicy.py
+++ b/Lib/ldap/controls/ppolicy.py
@@ -73,7 +73,7 @@ class PasswordPolicyControl(ValueLessRequestControl,ResponseControl):
   def decodeControlValue(self,encodedControlValue):
     ppolicyValue,_ = decoder.decode(encodedControlValue,asn1Spec=PasswordPolicyResponseValue())
     warning = ppolicyValue.getComponentByName('warning')
-    if warning is None:
+    if warning is None or not warning.hasValue():
       self.timeBeforeExpiration,self.graceAuthNsRemaining = None,None
     else:
       timeBeforeExpiration = warning.getComponentByName('timeBeforeExpiration')
@@ -87,7 +87,7 @@ class PasswordPolicyControl(ValueLessRequestControl,ResponseControl):
       else:
         self.graceAuthNsRemaining = None
     error = ppolicyValue.getComponentByName('error')
-    if error is None:
+    if error is None or not error.hasValue():
       self.error = None
     else:
       self.error = int(error)

--- a/Lib/ldap/controls/psearch.py
+++ b/Lib/ldap/controls/psearch.py
@@ -117,18 +117,16 @@ class EntryChangeNotificationControl(ResponseControl):
   def decodeControlValue(self,encodedControlValue):
     ecncValue,_ = decoder.decode(encodedControlValue,asn1Spec=EntryChangeNotificationValue())
     self.changeType = int(ecncValue.getComponentByName('changeType'))
-    if len(ecncValue)==3:
-      self.previousDN = str(ecncValue.getComponentByName('previousDN'))
-      self.changeNumber = int(ecncValue.getComponentByName('changeNumber'))
-    elif len(ecncValue)==2:
-      if self.changeType==8:
-        self.previousDN = str(ecncValue.getComponentByName('previousDN'))
-        self.changeNumber = None
-      else:
-        self.previousDN = None
-        self.changeNumber = int(ecncValue.getComponentByName('changeNumber'))
+    previousDN = ecncValue.getComponentByName('previousDN')
+    if previousDN is None or not previousDN.hasValue():
+      self.previousDN = None
     else:
-      self.previousDN,self.changeNumber = None,None
+      self.previousDN = str(previousDN)
+    changeNumber = ecncValue.getComponentByName('changeNumber')
+    if changeNumber is None or not changeNumber.hasValue():
+      self.changeNumber = None
+    else:
+      self.changeNumber = int(changeNumber)
     return (self.changeType,self.previousDN,self.changeNumber)
 
 KNOWN_RESPONSE_CONTROLS[EntryChangeNotificationControl.controlType] = EntryChangeNotificationControl

--- a/Lib/ldap/controls/sss.py
+++ b/Lib/ldap/controls/sss.py
@@ -123,7 +123,11 @@ class SSSResponseControl(ResponseControl):
         assert not rest, 'all data could not be decoded'
         self.result = int(p.getComponentByName('sortResult'))
         self.result_code = p.getComponentByName('sortResult').prettyOut(self.result)
-        self.attribute_type_error = p.getComponentByName('attributeType')
+        attribute_type_error = p.getComponentByName('attributeType')
+        if attribute_type_error is None or not attribute_type_error.hasValue():
+            self.attribute_type_error = None
+        else:
+            self.attribute_type_error = attribute_type_error
 
 
 KNOWN_RESPONSE_CONTROLS[SSSRequestControl.controlType] = SSSRequestControl

--- a/Lib/ldap/controls/vlv.py
+++ b/Lib/ldap/controls/vlv.py
@@ -132,8 +132,11 @@ class VLVResponseControl(ResponseControl):
         self.result = int(p.getComponentByName('virtualListViewResult'))
         self.result_code = p.getComponentByName('virtualListViewResult') \
                 .prettyOut(self.result)
-        self.context_id = p.getComponentByName('contextID')
-        if self.context_id:
-            self.context_id = str(self.context_id)
+        context_id = p.getComponentByName('contextID')
+        if context_id is None or not context_id.hasValue():
+            self.context_id = None
+        else:
+            self.context_id = str(context_id)
+
 
 KNOWN_RESPONSE_CONTROLS[VLVResponseControl.controlType] = VLVResponseControl

--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -271,7 +271,7 @@ class SyncInfoMessage:
         for attr in [ 'newcookie', 'refreshDelete', 'refreshPresent', 'syncIdSet']:
             comp = d[0].getComponentByName(attr)
 
-            if comp is not None:
+            if comp is not None and comp.hasValue():
 
                 if attr == 'newcookie':
                     self.newcookie = str(comp)

--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -135,11 +135,13 @@ class SyncStateControl(ResponseControl):
         # In Python 3, pyasn1.char overrides bytes() to do encoding for us.
         # See also http://pyasn1.sourceforge.net/docs/type/univ/octetstring.html
         uuid = UUID(bytes=bytes(d[0].getComponentByName('entryUUID')))
-        self.cookie = d[0].getComponentByName('cookie')
+        cookie = d[0].getComponentByName('cookie')
+        if cookie is None or not cookie.hasValue():
+            self.cookie = None
+        else:
+            self.cookie = str(cookie)
         self.state = self.__class__.opnames[int(state)]
         self.entryUUID = str(uuid)
-        if self.cookie is not None:
-            self.cookie = str(self.cookie)
 
 KNOWN_RESPONSE_CONTROLS[SyncStateControl.controlType] = SyncStateControl
 
@@ -169,10 +171,12 @@ class SyncDoneControl(ResponseControl):
 
     def decodeControlValue(self, encodedControlValue):
         d = decoder.decode(encodedControlValue, asn1Spec = syncDoneValue())
-        self.cookie = d[0].getComponentByName('cookie')
+        cookie = d[0].getComponentByName('cookie')
+        if cookie is None or not cookie.hasValue():
+            self.cookie = None
+        else:
+            self.cookie = str(cookie)
         self.refreshDeletes = d[0].getComponentByName('refreshDeletes')
-        if self.cookie is not None:
-            self.cookie = str(self.cookie)
         if self.refreshDeletes is not None:
             self.refreshDeletes = bool(self.refreshDeletes)
 
@@ -276,7 +280,7 @@ class SyncInfoMessage:
                 val = dict()
 
                 cookie = comp.getComponentByName('cookie')
-                if cookie is not None:
+                if cookie is not None and cookie.hasValue():
                     val['cookie'] = str(cookie)
 
                 if attr.startswith('refresh'):


### PR DESCRIPTION
pyasn1 versions prior to 0.2.3 indicate absent value by returning `None` object, later pyasn1 versions use
the `noValue` sentinel object which is the basis for the `.hasValue()` method call (and .isValue property).

This fix makes the code compatible with both `None` sentinel and the `.hasValue()` test call thus making it compatible with all reasonable pyasn1 versions in circulation.

See also https://github.com/akkornel/syncrepl/issues/18, [https://bugzilla.redhat.com/show_bug.cgi?id=1489184](https://bugzilla.redhat.com/show_bug.cgi?id=1489184)
