### PR TITLE
Add workaround for atexit cleanup

### DIFF
--- a/Lib/slapdtest.py
+++ b/Lib/slapdtest.py
@@ -157,6 +157,9 @@ class SlapdObject(object):
         """
         Recursively delete whole directory specified by `path'
         """
+        # cleanup_rundir() is called in atexit handler. Until Python 3.4,
+        # the rest of the world is already destroyed.
+        import os, os.path
         if not os.path.exists(self.testrundir):
             return
         self._log.debug('clean-up %s', self.testrundir)


### PR DESCRIPTION
Until Python 3.5, Python destroys most of the world before the atexit
callback has a change to clean up. This leads to exceptions like:

```
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/home/heimes/dev/redhat/pyldap/Lib/slapdtest.py", line 303, in stop
    self._cleanup_rundir()
  File "/home/heimes/dev/redhat/pyldap/Lib/slapdtest.py", line 160, in _cleanup_rundir
    if not os.path.exists(self.testrundir):
AttributeError: 'NoneType' object has no attribute 'path'
```

import os, os.path to resurrect the os module.

Signed-off-by: Christian Heimes <cheimes@redhat.com>