### PR TITLE
Ignore extension modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 __pycache__/
 .tox
 
+# shared libs installed 'setup.py test'
+/Lib/*.so*
+/Lib/*.dylib
+/Lib/*.pyd
+
 # Build related
 *.egg-info
 build/


### PR DESCRIPTION
setup.py test uses inplace installation of extension modules.

Signed-off-by: Christian Heimes <cheimes@redhat.com>