### PR TITLE
Move "sys.exc_info()" back to start of try block to fix py2 behavior

### DIFF
--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -297,6 +297,7 @@ class SimpleLDAPObject:
       finally:
         self._ldap_object_lock.release()
     except LDAPError as e:
+      exc_type,exc_value,exc_traceback = sys.exc_info()
       try:
         if 'info' not in e.args[0] and 'errno' in e.args[0]:
           e.args[0]['info'] = strerror(e.args[0]['errno'])
@@ -304,7 +305,10 @@ class SimpleLDAPObject:
         pass
       if __debug__ and self._trace_level>=2:
         self._trace_file.write('=> LDAPError - %s: %s\n' % (e.__class__.__name__,str(e)))
-      reraise(*sys.exc_info())
+      try:
+        reraise(exc_type, exc_value, exc_traceback)
+      finally:
+        exc_type = exc_value = exc_traceback = None
     else:
       if __debug__ and self._trace_level>=2:
         if not diagnostic_message_success is None:

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -299,7 +299,16 @@ class Test01_SimpleLDAPObject(SlapdTestCase):
         l = self.ldap_object_class(self.server.ldapi_uri)
         l.sasl_external_bind_s(authz_id=authz_id)
         self.assertEqual(l.whoami_s(), authz_id.lower())
-        
+
+    def test_timeout(self):
+        l = self.ldap_object_class(self.server.ldap_uri)
+
+        m = l.search_ext(self.server.suffix, ldap.SCOPE_SUBTREE, '(objectClass=*)')
+        l.abandon(m)
+
+        with self.assertRaises(ldap.TIMEOUT):
+            result = l.result(m, timeout=0.1)
+
 
 class Test02_ReconnectLDAPObject(Test01_SimpleLDAPObject):
     """


### PR DESCRIPTION
Instead, del the temporaty variables explicitly to prevent cycles

This fixes commit d16bccbf41e72fb934113ead94670c864b000dd5.

See https://github.com/pyldap/pyldap/pull/133#issuecomment-344883573