### PR TITLE
Tests/ scripts do not directly call SlapdTestCase.setUpClass() anymore

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@ Lib/
 
 Tests/
 * removed work-around in t_cext.py
+* scripts do not directly call SlapdTestCase.setUpClass() anymore
+  (in pyldap, cherry-picked from python-ldap 2.5.2)
 
 ----------------------------------------------------------------
 Released 2.4.44 2017-09-08 (upstream)

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -28,7 +28,7 @@ class TestLdapCExtension(SlapdTestCase):
 
     @classmethod
     def setUpClass(cls):
-        SlapdTestCase.setUpClass()
+        super(TestLdapCExtension, cls).setUpClass()
         # add two initial objects after server was started and is still empty
         suffix_dc = cls.server.suffix.split(',')[0][3:]
         cls.server._log.debug(

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -70,7 +70,7 @@ class Test01_SimpleLDAPObject(SlapdTestCase):
 
     @classmethod
     def setUpClass(cls):
-        SlapdTestCase.setUpClass()
+        super(Test01_SimpleLDAPObject, cls).setUpClass()
         # insert some Foo* objects via ldapadd
         cls.server.ldapadd(
             LDIF_TEMPLATE % {


### PR DESCRIPTION
Cherry-picked from python-ldap 2.5.2

Fixes: https://github.com/pyldap/pyldap/pull/122

I'd like to get this into pyldap 2.4.45 before I release that.