### PR TITLE
Minimize diff with python-ldap, and deprecate pyldap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 __pycache__/
 .tox
 
-# shared libs installed 'setup.py test'
+# shared libs installed by 'setup.py test'
 /Lib/*.so*
 /Lib/*.dylib
 /Lib/*.pyd

--- a/Demo/ldapurl_search.py
+++ b/Demo/ldapurl_search.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys,pprint,ldap
 

--- a/Demo/pyasn1/syncrepl.py
+++ b/Demo/pyasn1/syncrepl.py
@@ -143,8 +143,6 @@ signal.signal(signal.SIGINT, commenceShutdown)
 
 
 try:
-  ldap_url = ldapurl.LDAPUrl(sys.argv[1])
-  database_path = sys.argv[2]
     ldap_url = ldapurl.LDAPUrl(sys.argv[1])
     database_path = sys.argv[2]
 except IndexError,e:
@@ -160,8 +158,8 @@ except IndexError,e:
     ).format(script_name=sys.argv[0])
     sys.exit(1)
 except ValueError as e:
-  print('Error parsing command-line arguments:',str(e))
-  sys.exit(1)
+    print('Error parsing command-line arguments:',str(e))
+    sys.exit(1)
 
 while watcher_running:
     logger.info('Connecting to %s now...', ldap_url.initializeUrl())

--- a/Doc/index.rst
+++ b/Doc/index.rst
@@ -34,6 +34,43 @@ Contents
    slapdtest.rst
 
 
+
+*********************
+Bytes/text management
+*********************
+
+The LDAP protocol states that some fields (distinguised names, relative distinguished names,
+attribute names, queries) be encoded in UTF-8; some other (mostly attribute *values*) **MAY**
+contain any type of data, and thus be treated as bytes.
+
+In Python 2, ``python-ldap`` used bytes for all fields, including those guaranteed to be text.
+In order to support Python 3, this distinction is made explicit. This is done
+through the ``bytes_mode`` flag to ``ldap.initialize()``.
+
+When porting from ``python-ldap`` 2.x, users are advised to update their code to set ``bytes_mode=False``
+on calls to these methods.
+Under Python 2, ``python-pyldap`` aggressively checks the type of provided arguments, and will raise a ``TypeError``
+for any invalid parameter.
+However, if the ``bytes_mode`` kwarg isn't provided, ``pyldap`` will only
+raise warnings.
+
+The typical usage is as follows; note that only the result's *values* are of the bytes type:
+
+.. code-block:: pycon
+
+    >>> import ldap
+    >>> con = ldap.initialize('ldap://localhost:389', bytes_mode=False)
+    >>> con.simple_bind_s('login', 'secret_password')
+    >>> results = con.search_s('ou=people,dc=example,dc=org', ldap.SCOPE_SUBTREE, "(cn=Raphaël)")
+    >>> results
+    [
+        ("cn=Raphaël,ou=people,dc=example,dc=org", {
+            'cn': [b'Rapha\xc3\xabl'],
+            'sn': [b'Barrois'],
+        }),
+    ]
+
+
 ******************
 Indices and tables
 ******************

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -26,8 +26,6 @@ from _ldap import *
 # call into libldap to initialize it right now
 LIBLDAP_API_INFO = _ldap.get_option(_ldap.OPT_API_INFO)
 
-PYLDAP_VERSION = __version__
-
 OPT_NAMES_DICT = {}
 for k,v in vars(_ldap).items():
   if k.startswith('OPT_'):

--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -150,8 +150,6 @@ class SyncStateControl(ResponseControl):
     def decodeControlValue(self, encodedControlValue):
         d = decoder.decode(encodedControlValue, asn1Spec=SyncStateValue())
         state = d[0].getComponentByName('state')
-        # In Python 3, pyasn1.char overrides bytes() to do encoding for us.
-        # See also http://pyasn1.sourceforge.net/docs/type/univ/octetstring.html
         uuid = UUID(bytes=bytes(d[0].getComponentByName('entryUUID')))
         cookie = d[0].getComponentByName('cookie')
         if cookie is not None and cookie.hasValue():
@@ -337,9 +335,6 @@ class SyncInfoMessage:
                     uuids = []
                     ids = comp.getComponentByName('syncUUIDs')
                     for i in range(len(ids)):
-                        # In Python 3, pyasn1.char overrides bytes() to do
-                        # encoding for us.  See also:
-                        # http://pyasn1.sourceforge.net/docs/type/univ/octetstring.html
                         uuid = UUID(bytes=bytes(ids.getComponentByPosition(i)))
                         uuids.append(str(uuid))
                     val['syncUUIDs'] = uuids

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -303,8 +303,8 @@ class LDIFParser:
   def _readline(self):
     s = self._input_file.readline()
     if self._file_sends_bytes:
-      # The RFC does not allow UTF-8 values, but some implementations do,
-      # including upstream.
+      # The RFC does not allow UTF-8 values; we support it as a
+      # non-official, backwards compatibility layer
       s = s.decode('utf-8')
     self.line_counter = self.line_counter + 1
     self.byte_counter = self.byte_counter + len(s)

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -200,9 +200,9 @@ class LDIFWriter:
     dn = dn.encode('utf-8')
     self._unparseAttrTypeandValue('dn', dn)
     # Dispatch to record type specific writers
-    if isinstance(record, dict):
+    if isinstance(record,dict):
       self._unparseEntryRecord(record)
-    elif isinstance(record, list):
+    elif isinstance(record,list):
       self._unparseChangeRecord(record)
     else:
       raise ValueError('Argument record must be dictionary or list instead of %s' % (repr(record)))

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -22,14 +22,7 @@ __all__ = [
 
 import re
 from base64 import b64encode, b64decode
-
-try:
-  from cStringIO import StringIO
-except ImportError:
-  try:
-    from StringIO import StringIO
-  except ImportError:
-    from io import StringIO
+from io import StringIO
 
 from ldap.compat import urlparse, urlopen
 

--- a/Lib/slapdtest.py
+++ b/Lib/slapdtest.py
@@ -226,9 +226,10 @@ class SlapdObject(object):
 
     def _write_config(self):
         """Writes the slapd.conf file out, and returns the path to it."""
-        self._log.debug("Writing config to %s", self._slapd_conf)
+        self._log.debug('Writing config to %s', self._slapd_conf)
         with open(self._slapd_conf, 'w') as config_file:
             config_file.write(self.gen_config())
+        self._log.info('Wrote config to %s', self._slapd_conf)
 
     def _test_config(self):
         self._log.debug('testing config %s', self._slapd_conf)

--- a/Modules/common.h
+++ b/Modules/common.h
@@ -28,14 +28,8 @@ void LDAPadd_methods( PyObject*d, PyMethodDef*methods );
 #define PyNone_Check(o) ((o) == Py_None)
 
 /* Py2/3 compatibility */
-#if PY_VERSION_HEX < 0x03000000
-/* Python 2.x */
-#define PyBytes_Check PyString_Check
-#define PyBytes_Size PyString_Size
-#define PyBytes_AsString PyString_AsString
-#define PyBytes_FromStringAndSize PyString_FromStringAndSize
-#else
-/* Python 3.x */
+#if PY_VERSION_HEX >= 0x03000000
+/* In Python 3, alias PyInt to PyLong */
 #define PyInt_FromLong PyLong_FromLong
 #endif
 

--- a/Modules/message.c
+++ b/Modules/message.c
@@ -102,8 +102,8 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls, int add_intermedi
 	      attr = ldap_next_attribute( ld, entry, ber )
 	 ) {
 	     PyObject* valuelist;
-             PyObject* pyattr;
-             pyattr = PyUnicode_FromString(attr);
+	     PyObject* pyattr;
+	     pyattr = PyUnicode_FromString(attr);
 
 	     struct berval ** bvals =
 	     	ldap_get_values_len( ld, entry, attr );
@@ -121,8 +121,8 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls, int add_intermedi
 	     }
 
 	     if (valuelist == NULL) {
+		Py_DECREF(pyattr);
                 Py_DECREF(pydn);
-                Py_DECREF(pyattr);
 		Py_DECREF(attrdict);
 		Py_DECREF(result);
 		if (ber != NULL)
@@ -141,8 +141,8 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls, int add_intermedi
 
 		    valuestr = LDAPberval_to_object(bvals[i]);
 		    if (PyList_Append( valuelist, valuestr ) == -1) {
+		        Py_DECREF(pyattr);
                         Py_DECREF(pydn);
-                        Py_DECREF(pyattr);
 			Py_DECREF(attrdict);
 			Py_DECREF(result);
 			Py_DECREF(valuestr);
@@ -159,7 +159,7 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls, int add_intermedi
 	    	}
 		ldap_value_free_len(bvals);
 	     }
-             Py_DECREF(pyattr);
+	     Py_DECREF(pyattr);
 	     Py_DECREF( valuelist );
 	     ldap_memfree(attr);
 	 }

--- a/README
+++ b/README
@@ -112,6 +112,27 @@ These very kind people have supplied patches or suggested changes:
 * Andreas Hasenack <ahasenack at terra.com.br>
 * Matej Vela <vela at debian.org>
 
+These people contributed to Python 3 porting (at https://github.com/pyldap/):
+* A. Karl Kornel <akkornel at stanford.edu>
+* Alex Willmer <alex at moreati.org.uk>
+* Aymeric Augustin <aymeric.augustin at oscaro.com>
+* Bradley Baetz <bbaetz at google.com>
+* Christian Heimes <cheimes at redhat.com>
+* Dirk Mueller <dirk at dmllr.de>
+* Jon Dufresne <jon.dufresne at gmail.com>
+* Martin Basti <mbasti at redhat.com>
+* Miro Hroncok <miro at hroncok.cz>
+* Paul Aurich <paul at darkrain42.org>
+* Petr Viktorin <pviktori at redhat.com>
+* Pieterjan De Potter <pieterjan.depotter at ugent.be>
+* Raphaël Barrois <raphael.barrois at polyconseil.fr>
+* Robert Kuska <rkuska at redhat.com>
+* Stanislav Láznička <stlaz at users.noreply.github.com>
+* Tobias Bräutigam <tobias.braeutigam at gonicus.de>
+* Tom van Dijk <t.vandijk at utwente.nl>
+* Wentao Han <wentao.han at gmail.com>
+* William Brown <firstyear at redhat.com>
+
 Thanks to all the guys on the python-ldap mailing list for
 their contributions and input into this package.
 

--- a/README
+++ b/README
@@ -1,71 +1,14 @@
-======
-pyldap
-======
+-----------------------
+THIS FORK IS DEPRECATED
+-----------------------
+
+The pyldap fork will be merged back into python-ldap soon.
+This repository is now used for staging preparations.
+
 
 .. image:: https://travis-ci.org/pyldap/pyldap.svg?branch=master
     :target: https://travis-ci.org/pyldap/pyldap
     :alt: Continuous integration status
-
-pyldap is a fork of the excellent ``python-ldap`` Python project.
-
-The goals of this fork are the following:
-
-* Bring Python 3 support to ``python-ldap`` while keeping a PY2-compatible codebase
-* Improve tooling and code quality
-* Keep backwards compatibility whenever possible
-
------------------------
-Backwards compatibility
------------------------
-
-Users should be able to replace ``python-ldap`` with ``pyldap`` with minimal impact on their code.
-According to this, releases of ``pyldap`` will stick to the numbering of the upstream ``python-ldap`` releases they are based on.
-
-However, some compatibility toggles will be added to bring cleaner APIs for PY3 code.
-
-Please note the ``pyldap`` installs under the same ``ldap`` module as ``python-ldap``; it **CANNOT** be installed alongside.
-
-
---------------------------
-Upgrading from python-ldap
---------------------------
-
-``pyldap`` brings some improvements on top of ``python-ldap``.
-
-
-Bytes/text management
-=====================
-
-The LDAP protocol states that some fields (distinguised names, relative distinguished names,
-attribute names, queries) be encoded in UTF-8; some other (mostly attribute *values*) **MAY**
-contain any type of data, and thus be treated as bytes.
-
-However, ``python-ldap`` used bytes for all fields, including those guaranteed to be text.
-In order to support Python 3, ``pyldap`` needs to make this distinction explicit; this is done
-through the ``bytes_mode`` flag to ``ldap.initialize()``.
-
-When porting from ``python-ldap``, users are advised to update their code to set ``bytes_mode=False``
-on calls to these methods.
-Under Python 2, ``pyldap`` checks aggressively the type of provided arguments, and will raise a ``TypeError``
-for any invalid parameter; however, if the ``bytes_mode`` kwarg isn't provided, ``pyldap`` will only
-raise warnings.
-
-The typical usage is as follow; note that only the result's *values* are of the bytes type:
-
-.. code-block:: pycon
-
-    >>> import ldap
-    >>> con = ldap.initialize('ldap://localhost:389', bytes_mode=False)
-    >>> con.simple_bind_s('login', 'secret_password')
-    >>> results = con.search_s('ou=people,dc=example,dc=org', ldap.SCOPE_SUBTREE, "(cn=Raphaël)")
-    >>> results
-    [
-        ("cn=Raphaël,ou=people,dc=example,dc=org", {
-            'cn': [b'Rapha\xc3\xabl'],
-            'sn': [b'Barrois'],
-        }),
-    ]
-
 
 ---------------------------------------
 python-ldap: LDAP client API for Python

--- a/Tests/__init__.py
+++ b/Tests/__init__.py
@@ -7,6 +7,7 @@ See https://www.python-ldap.org/ for details.
 
 from __future__ import absolute_import
 
+from . import t_bind
 from . import t_cext
 from . import t_cidict
 from . import t_ldap_dn

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -209,7 +209,7 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertTrue('objectClass' in root_dse)
         self.assertTrue(b'OpenLDAProotDSE' in root_dse['objectClass'])
         self.assertTrue('namingContexts' in root_dse)
-        self.assertEquals(root_dse['namingContexts'], [self.server.suffix.encode('ascii')])
+        self.assertEqual(root_dse['namingContexts'], [self.server.suffix.encode('ascii')])
 
     def test_unbind(self):
         l = self._open_conn()

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -307,15 +307,13 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         l.sasl_external_bind_s(authz_id=authz_id)
         self.assertEqual(l.whoami_s(), authz_id.lower())
 
-    def test_timeout(self):
+    def test007_timeout(self):
         l = self.ldap_object_class(self.server.ldap_uri)
-
         m = l.search_ext(self.server.suffix, ldap.SCOPE_SUBTREE, '(objectClass=*)')
         l.abandon(m)
-
         with self.assertRaises(ldap.TIMEOUT):
             result = l.result(m, timeout=0.001)
-
+        
 
 class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ optimize = 1
 [bdist_rpm]
 provides = python-ldap
 requires = python libldap-2_4
-vendor = pyldap project
-packager = PyLDAP team
+vendor = python-ldap project
+packager = python-ldap team
 distribution_name = openSUSE 11.x
 release = 1
 doc_files = CHANGES README INSTALL TODO Demo/

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ for i in range(len(LDAP_CLASS.extra_files)):
   LDAP_CLASS.extra_files[i]=(destdir, origfileslist)
 
 #-- Let distutils/setuptools do the rest
-name = 'pyldap'
+name = 'python-ldap'
 
 # Python 2.3.6+ and setuptools are needed to build eggs, so
 # let's handle setuptools' additional  keyword arguments to
@@ -78,16 +78,17 @@ setup(
   license=pkginfo.__license__,
   version=pkginfo.__version__,
   description = 'Python modules for implementing LDAP clients',
-  long_description = """pyldap:
-  pyldap is a fork of python-ldap, and provides an object-oriented API to access LDAP
-  directory servers from Python programs. Mainly it wraps the OpenLDAP 2.x libs for that purpose.
+  long_description = """python-ldap:
+  python-ldap provides an object-oriented API to access LDAP directory servers
+  from Python programs. Mainly it wraps the OpenLDAP 2.x libs for that purpose.
   Additionally the package contains modules for other LDAP-related stuff
   (e.g. processing LDIF, LDAPURLs, LDAPv3 schema, LDAPv3 extended operations
   and controls, etc.). 
   """,
-  author = 'pyldap project',
-  url = 'https://github.com/pyldap/pyldap/',
-  download_url = 'https://pypi.python.org/pypi/pyldap/',
+  author = 'python-ldap project',
+  author_email = 'python-ldap@python.org',
+  url = 'https://www.python-ldap.org/',
+  download_url = 'https://pypi.python.org/pypi/python-ldap/',
   classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
I checked our changes with respect to python-ldap, and found some that would be better reverted, or otherwise made smaller.

This change also re-brands the project back to python-ldap.

Except the warning in the README, the result is what I'd like to merge into python-ldap.