### PR TITLE
Update README and description

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,27 @@ To install the new code, use::
     pip install python-ldap
 
 Package pyldap 3.0 now exists only to require python-ldap.
+
+.. warning::
+
+    Unfortunately, due to `pip bug 4961`_, upgrading from previous versions
+    using ``pip`` makes the ``ldap`` module unimportable.
+
+    Instead of upgrading, please replace ``pyldap`` by ``python-ldap``
+    in two separate steps::
+
+        python -m pip uninstall pyldap
+        python -m pip install python-ldap
+
+    If upgraded already issue, you can fix your environment by uninstalling
+    and reinstalling ``python-ldap``::
+
+        python -m pip uninstall python-ldap
+        python -m pip install python-ldap
+
+    We are sorry for the inconvenience.
+    If you have a better solution, please join the discussion at `pyldap bug 148`_.
+
+
+.. _pip bug 4961: https://github.com/pypa/pip/issues/4961
+.. _pyldap bug 148: https://github.com/pyldap/pyldap/issues/148

--- a/README
+++ b/README
@@ -3,7 +3,7 @@ THIS FORK IS DEPRECATED
 -----------------------
 
 The pyldap fork was merged back into python-ldap,
-and released as python-ldap 3.0.0b1.
+and released as python-ldap 3.0.0.
 
 Development continues at:
 
@@ -11,7 +11,7 @@ Development continues at:
 
 Documentation is available at:
 
-    https://python-ldap.readthedocs.io/en/latest/
+    https://python-ldap.org/
 
 To install the new code, use::
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup
 
+with open('README.rst') as f:
+    long_description = f.read()
+
 setup(
     name = 'pyldap',
     license = 'Python style',
     version = '3.0.0',
     description = 'DEPRECATED; use python-ldap instead',
-    long_description = """
-        The pyldap fork was merged back into python-ldap,
-        and will be released as python-ldap 3.0.0.
-    """,
+    long_description = long_description,
     author = 'pyldap project',
     author_email = 'python-ldap@python.org',
     url = 'https://github.com/pyldap/pyldap/',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
 setup(
     name = 'pyldap',
     license = 'Python style',
-    version = '3.0.0',
+    version = '3.0.0.post1',
     description = 'DEPRECATED; use python-ldap instead',
     long_description = long_description,
     author = 'pyldap project',


### PR DESCRIPTION
- reflect that python-ldap 3.0.0 is out; change docs URL
- warn about pip issue #4961 and provide workarounds
- bump version to 3.0.0.post1 so this can be uploaded to PyPI